### PR TITLE
security: 書き込みを service role に限定し RLS を閉じる (refs #7)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,6 +3,10 @@
 NEXT_PUBLIC_SUPABASE_URL=your-project-url.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
+# サーバーサイド専用: RLS をバイパスする書き込み用クライアントで使用する
+# Project Settings → API → service_role key から取得（絶対にクライアントに露出させない）
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
 # Google Gemini API Configuration
 # https://makersuite.google.com/app/apikey から取得
 GEMINI_API_KEY=your-gemini-api-key

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ cp .env.local.example .env.local
 NEXT_PUBLIC_SUPABASE_URL=your-project-url.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
+# サーバーサイドの書き込み用（RLS をバイパス）
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
 # Google Gemini API設定（https://makersuite.google.com/app/apikey から取得）
 GEMINI_API_KEY=your-gemini-api-key
 

--- a/app/actions/generations.test.ts
+++ b/app/actions/generations.test.ts
@@ -15,8 +15,8 @@ const mockSelect = vi.fn();
 const mockInsert = vi.fn();
 const mockFrom = vi.fn();
 
-vi.mock("@/lib/supabase/server", () => ({
-  createClient: vi.fn(async () => ({
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
     from: mockFrom,
   })),
 }));

--- a/app/actions/generations.ts
+++ b/app/actions/generations.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { revalidatePath } from 'next/cache';
 import { after } from 'next/server';
 import type { GenerationInsert } from '@/types/database';
@@ -32,7 +32,7 @@ export async function createGeneration(
       };
     }
 
-    const supabase = await createClient();
+    const supabase = createAdminClient();
 
     // parent_idが指定されている場合、存在確認
     if (parentId) {
@@ -104,7 +104,7 @@ async function generateImageInBackground(generationId: string, prompt: string) {
     const imageUrl = await generateImage(prompt);
 
     // データベースを更新
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     const { error } = await supabase
       .from('generations')
       .update({
@@ -132,7 +132,7 @@ async function generateImageInBackground(generationId: string, prompt: string) {
 
     // エラー時はステータスを failed に更新
     try {
-      const supabase = await createClient();
+      const supabase = createAdminClient();
       await supabase
         .from('generations')
         .update({ status: 'failed' })
@@ -155,7 +155,7 @@ export async function createTestGeneration(
   error: string | null;
 }> {
   try {
-    const supabase = await createClient();
+    const supabase = createAdminClient();
 
     const newGeneration: GenerationInsert = {
       parent_id: null,

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,31 @@
+/**
+ * Supabase Admin Client (Service Role)
+ *
+ * RLS をバイパスするサーバー専用クライアント。書き込み（INSERT/UPDATE/DELETE）は
+ * このクライアント経由にし、anon クライアントでの書き込みは RLS で遮断する。
+ *
+ * ⚠️ Server Actions / Route Handlers / Server Components からのみ使用すること。
+ * Client Components にインポートされないよう注意（SERVICE_ROLE_KEY が漏洩する）。
+ */
+
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+
+export function createAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_URL is not set");
+  }
+  if (!serviceRoleKey) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY is not set");
+  }
+
+  return createSupabaseClient<Database>(url, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -8,6 +8,7 @@
  * Client Components にインポートされないよう注意（SERVICE_ROLE_KEY が漏洩する）。
  */
 
+import "server-only";
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@supabase/supabase-js": "^2.86.2",
         "next": "^15.1.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "server-only": "^0.0.1"
       },
       "devDependencies": {
         "@types/node": "^22",
@@ -6854,6 +6855,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "@supabase/supabase-js": "^2.86.2",
     "next": "^15.1.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/supabase/migrations/tighten_rls_service_role_only.sql
+++ b/supabase/migrations/tighten_rls_service_role_only.sql
@@ -1,0 +1,16 @@
+-- Migration: RLS を SELECT のみ公開に変更し、書き込み（INSERT/UPDATE/DELETE）を service_role 経由に限定する
+-- Issue: #7 security: RLSポリシーが全開放状態
+--
+-- 前提: アプリ側は lib/supabase/admin.ts の createAdminClient()（SUPABASE_SERVICE_ROLE_KEY）
+--       を使って書き込みを行うこと。service_role は Supabase のデフォルトで RLS をバイパスする。
+--       anon からの書き込みはポリシー不在により自動的に拒否される。
+
+-- 旧ポリシー（全開放）を削除
+DROP POLICY IF EXISTS "Enable insert access for all users" ON generations;
+DROP POLICY IF EXISTS "Enable update access for all users" ON generations;
+DROP POLICY IF EXISTS "Enable delete access for all users" ON generations;
+
+-- SELECT は公開ゲームのため全ユーザーに開放（既存ポリシーがあればスキップ）
+DROP POLICY IF EXISTS "Enable read access for all users" ON generations;
+CREATE POLICY "Enable read access for all users" ON generations
+  FOR SELECT USING (true);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -39,21 +39,17 @@ CREATE INDEX IF NOT EXISTS idx_generations_created_at ON generations(created_at 
 CREATE INDEX IF NOT EXISTS idx_generations_status ON generations(status);
 
 -- Row Level Security (RLS) を有効化
--- 本番環境では適切なポリシーを設定してください
 ALTER TABLE generations ENABLE ROW LEVEL SECURITY;
 
--- 開発用: 全員が読み書き可能なポリシー（本番では変更すること！）
+-- SELECT は公開ゲームのため全ユーザーに開放
 CREATE POLICY "Enable read access for all users" ON generations
   FOR SELECT USING (true);
 
-CREATE POLICY "Enable insert access for all users" ON generations
-  FOR INSERT WITH CHECK (true);
-
-CREATE POLICY "Enable update access for all users" ON generations
-  FOR UPDATE USING (true);
-
-CREATE POLICY "Enable delete access for all users" ON generations
-  FOR DELETE USING (true);
+-- INSERT / UPDATE / DELETE は service_role クライアント経由のみ許可する。
+-- service_role は Supabase のデフォルトで RLS をバイパスするため明示ポリシーは不要。
+-- anon クライアントからの書き込みはポリシー不在により自動的に拒否される。
+-- アプリ側は lib/supabase/admin.ts の createAdminClient() を使うこと。
+-- 将来ユーザー認証を導入する際は auth.uid() ベースのポリシーに差し替える。
 
 -- リーフノード取得関数（子を持たない完了済み世代）
 -- クライアント側での全件フェッチを避け、DB側でフィルタリング


### PR DESCRIPTION
## Summary
- **実害**: `supabase/schema.sql` の RLS が SELECT/INSERT/UPDATE/DELETE 全て `USING (true)` で全開放。本番 Vercel にデプロイ済み = anon key を持つ第三者が全レコードを改ざん・削除可能
- 認証機能未実装、`user_id` カラム無し、`SUPABASE_SERVICE_ROLE_KEY` 未設定 — `auth.uid()` ベースの policy は書けない状態
- **stopgap 方針**: 書き込みを service_role クライアント経由に限定し、anon からの INSERT/UPDATE/DELETE は RLS で拒否

## Changes
- **追加** `lib/supabase/admin.ts`: `SUPABASE_SERVICE_ROLE_KEY` を使うサーバー専用 Supabase クライアント (`createAdminClient()`)
- **変更** `app/actions/generations.ts`: `createGeneration` / `generateImageInBackground` / `createTestGeneration` の DB アクセスを admin client 経由に切替
- **変更** `supabase/schema.sql`: INSERT/UPDATE/DELETE の全開放ポリシーを削除、SELECT のみ公開
- **追加** `supabase/migrations/tighten_rls_service_role_only.sql`: 本番 DB 適用用マイグレーション
- **変更** `.env.local.example` / `README.md`: `SUPABASE_SERVICE_ROLE_KEY` 記載追加

読み取り専用の server components（gallery/play ページ等）は anon のままで変更なし（SELECT は引き続き公開）。

## デプロイ手順（重要）
1. **先に** Vercel 環境変数に `SUPABASE_SERVICE_ROLE_KEY` を追加（Production / Preview / Development）
2. Supabase Dashboard → SQL Editor で `supabase/migrations/tighten_rls_service_role_only.sql` を実行
3. この PR をマージ → Vercel 再デプロイ

順序を逆にすると「一時的に書き込み全不能」状態になるので注意。

## Test plan
- [x] `npx vitest run` — 全 25 テスト通過（`generations.test.ts` のモックも `@/lib/supabase/admin` に切替済）
- [ ] 手動: ローカル Supabase に migration 適用 → anon key での insert が RLS で弾かれる / service role での insert は通る、を確認
- [ ] 本番デプロイ後: gallery 画面が正常表示、画像生成アクションが正常動作

## 残タスク（別 Issue で継続）
- ユーザー認証（Supabase Auth）導入
- `generations` テーブルへの `user_id` カラム追加
- `auth.uid()` ベースの RLS policy に差し替え

refs #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
